### PR TITLE
Add "TOR compatibility" to LI, TOU_Miner applied to TOR-Trickster

### DIFF
--- a/LevelImposter/Core/Patches/ModCompatibility/TOU_MinerPatch.cs
+++ b/LevelImposter/Core/Patches/ModCompatibility/TOU_MinerPatch.cs
@@ -20,7 +20,7 @@ namespace LevelImposter.Core
         {
             if (MapLoader.CurrentMap == null)
                 return;
-            if (!ModCompatibility.IsTOUEnabled)
+            if (!ModCompatibility.IsTOUEnabled && !ModCompatibility.IsTOREnabled)
                 return;
             if (_ventTotal == ShipStatus.Instance.AllVents.Count)
                 return;
@@ -28,9 +28,10 @@ namespace LevelImposter.Core
             _ventTotal = ShipStatus.Instance.AllVents.Count;
             foreach (var vent in ShipStatus.Instance.AllVents)
             {
-                if (vent.name.EndsWith("(Clone)") && vent.transform.childCount == 1)
+                if ((vent.name.EndsWith("(Clone)") || vent.name.StartsWith("JackInTheBoxVent")) && vent.transform.childCount == 1)
                 {
-                    vent.name = $"TOU_Vent{vent.Id}";
+                    if (ModCompatibility.IsTOUEnabled)
+                        vent.name = $"TOU_Vent{vent.Id}";
 
                     ButtonBehavior[] ventButtons = vent.GetComponentsInChildren<ButtonBehavior>(true);
                     foreach (var ventButton in ventButtons)

--- a/LevelImposter/Core/Utils/ModCompatibility.cs
+++ b/LevelImposter/Core/Utils/ModCompatibility.cs
@@ -14,12 +14,15 @@ namespace LevelImposter.Core
         public const string TOU_GUID = "com.slushiegoose.townofus";
         public const string SUBMERGED_GUID = "Submerged";
         public const ShipStatus.MapType SUBMERGED_MAP_TYPE = (ShipStatus.MapType)5;
+        public const string TOR_GUID = "me.eisbison.theotherroles";
 
         private static bool _isTOUEnabled = false;
         private static bool _isSubmergedEnabled = false;
+        private static bool _isTOREnabled = false;
 
         public static bool IsTOUEnabled => _isTOUEnabled;
         public static bool IsSubmergedEnabled => _isSubmergedEnabled;
+        public static bool IsTOREnabled => _isTOREnabled;
 
         public static void Init()
         {
@@ -30,6 +33,10 @@ namespace LevelImposter.Core
             _isSubmergedEnabled = IL2CPPChainloader.Instance.Plugins.TryGetValue(SUBMERGED_GUID, out PluginInfo _);
             if (_isSubmergedEnabled)
                 LILogger.Info("LevelImposter detected Submerged installed, currently unsupported");
+
+            _isTOREnabled = IL2CPPChainloader.Instance.Plugins.TryGetValue(TOR_GUID, out PluginInfo _);
+            if (_isTOREnabled)
+                LILogger.Info("LevelImposter detected TOR installed, compatibility enabled");
         }
     }
 }

--- a/LevelImposter/LevelImposter.cs
+++ b/LevelImposter/LevelImposter.cs
@@ -14,6 +14,7 @@ namespace LevelImposter
     [BepInDependency(ModCompatibility.REACTOR_ID)]
     [BepInDependency(ModCompatibility.SUBMERGED_GUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(ModCompatibility.TOU_GUID, BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency(ModCompatibility.TOR_GUID, BepInDependency.DependencyFlags.SoftDependency)]
     [ReactorModFlags(Reactor.Networking.ModFlags.RequireOnAllClients)]
     [BepInProcess("Among Us.exe")]
     public partial class LevelImposter : BasePlugin


### PR DESCRIPTION
Hi,

when testing LI's compatibility with TOR, so far I only found the vent issue with the Trickster-Vents, which is solvable by applying the same patch as for TOU's Miner. It would be nice if you could include something like this in a future release. 

(Our Sabotage fix does not seem to cause problems - at least on Steampunk Skeld)

sidenote: I think las Monjas has a role named plumber, to which this patch could also apply. 
