### PR TITLE
Allow LITeleporters to be enabled/disabled

### DIFF
--- a/LevelImposter/Core/Components/LITeleporter.cs
+++ b/LevelImposter/Core/Components/LITeleporter.cs
@@ -20,6 +20,7 @@ namespace LevelImposter.Core
         private LIElement? _elem = null;
         private LITeleporter? _target = null;
         private bool _preserveOffset = true;
+        private bool _enabled = true;
 
         [HideFromIl2Cpp]
         public LIElement? CurrentElem => _elem;
@@ -35,6 +36,7 @@ namespace LevelImposter.Core
         {
             _elem = elem;
             _preserveOffset = elem.properties.preserveOffset ?? true;
+            _enabled = elem.properties.isEnabled ?? true;
         }
 
         /// <summary>
@@ -78,7 +80,7 @@ namespace LevelImposter.Core
             PlayerControl player = collider.GetComponent<PlayerControl>();
             if (player == null)
                 return;
-            if (_elem == null || _target == null)
+            if (_elem == null || _target == null || !_enabled)
                 return;
             if (!MapUtils.IsLocalPlayer(player.gameObject))
                 return;
@@ -114,6 +116,16 @@ namespace LevelImposter.Core
                 player.transform.position.x,
                 player.transform.position.y
             );
+        }
+
+        public void SetEnabled(bool enabled)
+        {
+            _enabled = enabled;
+        }
+
+        public bool isEnabled()
+        {
+            return _enabled;
         }
     }
 }

--- a/LevelImposter/Core/Components/LITriggerable.cs
+++ b/LevelImposter/Core/Components/LITriggerable.cs
@@ -187,6 +187,9 @@ namespace LevelImposter.Core
                     gameObject.SetActive(false);
                     StopComponents();
                     break;
+                case "toggle":
+                    ToggleComponents();
+                    break;
 
                 // Repeat
                 case "repeat":
@@ -298,6 +301,10 @@ namespace LevelImposter.Core
             TriggerSoundPlayer? triggerSound = GetComponent<TriggerSoundPlayer>();
             if (triggerSound != null)
                 triggerSound.Stop();
+            LITeleporter? teleporter = GetComponent<LITeleporter>();
+            if (teleporter != null)
+                teleporter.SetEnabled(false);
+
         }
 
         /// <summary>
@@ -320,6 +327,19 @@ namespace LevelImposter.Core
             TriggerSoundPlayer? triggerSound = GetComponent<TriggerSoundPlayer>();
             if (triggerSound != null)
                 triggerSound.Play(loop);
+            LITeleporter? teleporter = GetComponent<LITeleporter>();
+            if (teleporter != null)
+                teleporter.SetEnabled(true);
+        }
+
+        /// <summary>
+        /// Toggles the state of any component attached, i.e enables the component if it is currently disabled, and vice versa
+        /// </summary>
+        private void ToggleComponents(bool loop = true)
+        {
+            LITeleporter? teleporter = GetComponent<LITeleporter>();
+            if (teleporter != null)
+                teleporter.SetEnabled(!teleporter.isEnabled());
         }
 
         /// <summary>

--- a/LevelImposter/Core/Models/LIProperties.cs
+++ b/LevelImposter/Core/Models/LIProperties.cs
@@ -65,6 +65,7 @@ namespace LevelImposter.Core
 
         // Teleporter
         public Guid? teleporter { get; set; }
+        public bool? isEnabled { get; set; }
         public bool? preserveOffset { get; set; }
         public bool? isGhostEnabled { get; set; }
 


### PR DESCRIPTION
Added a variable _enabled to LITeleporter that controls whether the teleporter is enabled or not. Enabling/disabling teleporters can be done using the triggers "enable", "disable" and "toggle". The toggle trigger enables the teleporter if it is currently disabled, and disables it if is currently enabled. Since toggling component can be used for many types of components in the future, I decided to implement it generically. Whether the teleporter starts enabled is determined by the property isEnabled in LIProperties.