### PR TITLE
Fixed map shop HTTP download error

### DIFF
--- a/LevelImposter/Core/Patches/Ship/PlatformPatch.cs
+++ b/LevelImposter/Core/Patches/Ship/PlatformPatch.cs
@@ -56,9 +56,10 @@ public static class PlatformPatchRPC
             platform.Use(__instance);
         else
             // Request Use Platform
-            AmongUsClient.Instance.StartRpc(
+            AmongUsClient.Instance.StartRpcImmediately(
                 __instance.NetId,
-                (byte)RpcCalls.UsePlatform
+                (byte)RpcCalls.UsePlatform,
+                Hazel.SendOption.None
             ).EndMessage();
         return false;
     }

--- a/LevelImposter/LevelImposter.csproj
+++ b/LevelImposter/LevelImposter.csproj
@@ -17,23 +17,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.692" PrivateAssets="all"/>
-        <PackageReference Include="AmongUs.GameLibs.Steam" Version="$(GameVersion)" PrivateAssets="all"/>
-        <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all"/>
-        <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.1.0-rc.1" PrivateAssets="all"/>
-        <PackageReference Include="System.Text.Json" Version="6.0.10" PrivateAssets="all"/>
-        <PackageReference Include="Reactor" Version="2.2.0"/>
+        <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.692" PrivateAssets="all" />
+        <PackageReference Include="AmongUs.GameLibs.Steam" Version="2025.4.15" PrivateAssets="all" />
+        <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all" />
+        <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.1.0-rc.1" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Json" Version="6.0.10" PrivateAssets="all" />
+        <PackageReference Include="Reactor" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="Assets\**\*"/>
+        <EmbeddedResource Include="Assets\**\*" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\.editorconfig" Link=".editorconfig"/>
+        <None Include="..\.editorconfig" Link=".editorconfig" />
     </ItemGroup>
 
     <Target Name="Copy" AfterTargets="Build" Condition="'$(AmongUs)' != ''">
-        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(AmongUs)/BepInEx/plugins/" UseSymboliclinksIfPossible="true"/>
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(AmongUs)/BepInEx/plugins/" UseSymboliclinksIfPossible="true" />
     </Target>
 </Project>

--- a/LevelImposter/Shop/Components/HTTPHandler.cs
+++ b/LevelImposter/Shop/Components/HTTPHandler.cs
@@ -72,7 +72,7 @@ public class HTTPHandler(IntPtr intPtr) : MonoBehaviour(intPtr)
             }
             else if (onSuccessBytes != null)
             {
-                onSuccessBytes(request.downloadHandler.data);
+                onSuccessBytes(request.downloadHandler.GetUnstrippedData());
             }
 
             // Free memory (because BepInEx)

--- a/LevelImposter/Shop/Util/DownloadManager.cs
+++ b/LevelImposter/Shop/Util/DownloadManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using LevelImposter.Core;
 using Reactor.Networking.Attributes;
+using UnityEngine.Networking;
 
 namespace LevelImposter.Shop;
 
@@ -126,5 +127,18 @@ public static class DownloadManager
     {
         _downloadPercent = 0;
         MapUtils.WaitForPlayer(() => { RPCDownload(PlayerControl.LocalPlayer, true); });
+    }
+
+    /// <summary>
+    ///     Gets native data as a byte array. Replaces removed method: <c>DownloadHandler.InternalGetByteArray</c>
+    /// </summary>
+    public static byte[]? GetUnstrippedData(this DownloadHandler dh)
+    {
+        var nativeData = dh.GetNativeData();
+
+        if (nativeData.IsCreated)
+            return nativeData.ToArray();
+
+        return null;
     }
 }


### PR DESCRIPTION
## Issue
When opening the map shop in version 16.0.5 of Among Us, the map thumbnails fail to load and attempting to download a map fails at 99%. This happens due to to the removal of `DownloadHandler.InternalGetByteArray` in the latest version.

## Solution
I fixed this issue by bumping `AmongUs.GameLibs.Steam` to version 2025.4.15 and reimplementing the functionality of the removed method in the form of an extension method. Thanks to this [Discord message](https://discord.com/channels/766765155136307250/785869972810367066/1383837070241300500) for the reimplementation code.