### PR TITLE
Patch ShipStatus.BreakEmergencyButton with custom LI logic.

### DIFF
--- a/LevelImposter/Builders/Util/DummyBuilder.cs
+++ b/LevelImposter/Builders/Util/DummyBuilder.cs
@@ -1,23 +1,26 @@
 using LevelImposter.Core.Components;
 using LevelImposter.Core.Models;
 using LevelImposter.Core.Utils;
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace LevelImposter.Builders.Util;
 
 public class DummyBuilder : IElemBuilder
 {
+    public static Dictionary<Guid, int> DummyIndex { get; } = new();
+
     public void OnBuild(LIElement elem, GameObject obj)
     {
         if (elem.type != "util-dummy")
             return;
+        if (LIShipStatus.GetInstance().ShipStatus is not ShipStatus ship)
+            return;
 
-        // ShipStatus
-        var shipStatus = LIShipStatus.GetShip();
 
-        // Add Location
-        shipStatus.DummyLocations = shipStatus.DummyLocations.Add(obj.transform);
-
-        // TODO: Customize each dummy location with name/outfit
+        // Add location and save its index with the element id (see DummyPatch)
+        DummyIndex[elem.id] = ship.DummyLocations.Length;
+        ship.DummyLocations = ship.DummyLocations.Add(obj.transform);
     }
 }

--- a/LevelImposter/Core/Patches/Fixes/EmergencyButtonPatch.cs
+++ b/LevelImposter/Core/Patches/Fixes/EmergencyButtonPatch.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using LevelImposter.Core.Components;
+using LevelImposter.Core.Utils;
+
+namespace LevelImposter.Core.Patches.Fixes;
+
+/// <summary>
+///     Patches the Emergency Button breaking logic to destroy all buttons on the map.
+/// </summary>
+[HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.BreakEmergencyButton))]
+public static class EmergencyButtonPatch
+{
+    public static bool Prefix(ShipStatus __instance)
+    {
+        if (!LIShipStatus.IsInstance())
+            return true;
+
+        var ship = LIShipStatus.GetInstance();
+
+        foreach (var button in ship.transform.GetComponentsInChildren<SystemConsole>())
+        {
+            button.Image.sprite = __instance.BrokenEmergencyButton;
+            button.enabled = false;
+        }
+
+        LILogger.Msg("Hooked into ShipStatus.BreakEmergencyButton() and broke all emergency buttons.");
+
+        return false;
+    }
+}

--- a/LevelImposter/Core/Patches/Ship/DummyPatch.cs
+++ b/LevelImposter/Core/Patches/Ship/DummyPatch.cs
@@ -1,5 +1,8 @@
 ﻿using HarmonyLib;
-using LevelImposter.Shop;
+using LevelImposter.Builders.Util;
+using LevelImposter.Core.Components;
+using LevelImposter.Core.Models;
+using LevelImposter.Core.Utils;
 using System.Linq;
 
 namespace LevelImposter.Core;
@@ -18,7 +21,7 @@ public static class DummyPatch
             return;
         if (!GameState.IsInFreeplay)
             return;
-        if(MapLoader.CurrentMap == null)
+        if(LIShipStatus.GetInstance().CurrentMap is null)
             return;
 
         // Since the game is in freeplay, removing the local player just leaves all the dummy PlayerControls
@@ -26,11 +29,11 @@ public static class DummyPatch
 
         // Finds a dummy element that has a corresponding location index (see DummyBuilder)
         // which matches this DummyBehaviour's PlayerControl
-        foreach (var elem in MapLoader.CurrentMap.elements)
+        foreach (var elem in LIShipStatus.GetInstance().CurrentMap!.elements)
         {
             if(elem.type != "util-dummy")
                 continue;
-            if (!LIShipStatus.GetInstance().DummyIndex.TryGetValue(elem.id, out int index))
+            if (!DummyBuilder.DummyIndex.TryGetValue(elem.id, out int index))
                 continue;
             if (__instance.myPlayer != dummyPlayers[index])
                 continue;


### PR DESCRIPTION
I ran into an issue while developing another mod, where the game screen would be mostly obstructed and the console would yield the following error in the Hide and Seek game mode:

<img width="1919" height="1079" alt="Screenshot_1" src="https://github.com/user-attachments/assets/18d2b1c5-155e-4c57-9248-c9c8faa70992" />

```
[Error  :Il2CppInterop] Exception in IL2CPP-to-Managed trampoline, not passing it to il2cpp: Il2CppInterop.Runtime.Il2CppException: System.NullReferenceException: Object reference not set to an instance of an object.
--- BEGIN IL2CPP STACK TRACE ---
System.NullReferenceException: Object reference not set to an instance of an object.
  at ShipStatus.BreakEmergencyButton () [0x00000] in <00000000000000000000000000000000>:0
--- END IL2CPP STACK TRACE ---

   at Il2CppInterop.Runtime.Il2CppException.RaiseExceptionIfNecessary(IntPtr returnedException) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Il2CppException.cs:line 36
   at ShipStatus.BreakEmergencyButton()
   at CrewmeleonRedrawn.GameMode.ChameleonIntro.Play(IntroCutscene intro)+MoveNext()
   at Trampoline_ByteThisBepInEx.Unity.IL2CPP.Utils.Collections.Il2CppManagedEnumeratorMoveNext(IntPtr , Il2CppMethodInfo* )
```

I then applied a quick patch that cancels the original logic, and instead manually searches for all emergency buttons on the map. I recognise the potential performance issues of my basic approach, but it's probably best if you decide whether you want to store all `SystemConsole` instances in a builder or do something else. My goal was to make you aware of this issue and provide a potential fix, so here you go :).

_Sidenote: I also noticed an issue while trying to build the project caused by my previous custom dummy names feature being partially reverted, so I added back the missing sections._